### PR TITLE
Scenario Load Error

### DIFF
--- a/src/scenario/scenario.js
+++ b/src/scenario/scenario.js
@@ -24,7 +24,7 @@ Scenario.prototype.scenarioSetPaths = function () {
         this.path = this.app.path.dirname(path);
 
     } else {
-        this.h.abort("Could not locate scenario file: " + path);
+        this.app.h.abort("Could not locate scenario file: " + path);
     }
 };
 


### PR DESCRIPTION
Throws an error instead of gracefully aborting if scenario file not found